### PR TITLE
Bump Kaimoji version

### DIFF
--- a/_packages/kaimoji.md
+++ b/_packages/kaimoji.md
@@ -2,7 +2,7 @@
 package_name: "kaimoji"
 package_title: "Kaimoji"
 package_desc: "A package providing Kaimoji expansions"
-package_version: "0.1.0"
+package_version: "0.1.1"
 package_author: "Ian Pringle"
 package_original_repo: "https://github.com/pard68/kaimoji"
 package_repo: "https://github.com/federico-terzi/espanso-hub-core"


### PR DESCRIPTION
Version bump is to correct an issue where `\` is not escaped on the shrug kaimoji.

Not sure if this is the right way to update package versions. Docs don't mention updating packages.