### PR TITLE
Add `--external` flag to installation instruction

### DIFF
--- a/_packages/mispell-en.md
+++ b/_packages/mispell-en.md
@@ -17,8 +17,7 @@ The package is based on [github.com/client9/misspell](https://github.com/client9
 Install the package with:
 
 ```
-espanso install misspell-en
-espanso restart
+espanso install misspell-en --external && espanso restart
 ```
 
 ## Usage


### PR DESCRIPTION
Without this flag, package does not install.
If package is not installed, why restart espanso ? Hence added `&&`